### PR TITLE
Misc tweaks

### DIFF
--- a/PKHeX.Core/PersonalInfo/Info/PersonalInfo8LA.cs
+++ b/PKHeX.Core/PersonalInfo/Info/PersonalInfo8LA.cs
@@ -192,7 +192,7 @@ public sealed class PersonalInfo8LA(Memory<byte> Raw) : PersonalInfo, IPersonalA
     {
         var moves = MoveShopMoves;
         var bits = MoveShopBits;
-        for (int index = 0 ; index < MoveShopCount; index++)
+        for (int index = 0; index < MoveShopCount; index++)
         {
             if ((bits & 1) == 1)
                 result[moves[index]] = true;

--- a/PKHeX.Core/Saves/SAV5.cs
+++ b/PKHeX.Core/Saves/SAV5.cs
@@ -109,7 +109,7 @@ public abstract class SAV5 : SaveFile, ISaveBlock5BW, IEventFlagProvider37, IBox
     public override int PlayedSeconds { get => PlayerData.PlayedSeconds; set => PlayerData.PlayedSeconds = value; }
     public override uint Money { get => Misc.Money; set => Misc.Money = value; }
     public override uint SecondsToStart { get => AdventureInfo.SecondsToStart; set => AdventureInfo.SecondsToStart = value; }
-    public override uint SecondsToFame  { get => AdventureInfo.SecondsToFame ; set => AdventureInfo.SecondsToFame  = value; }
+    public override uint SecondsToFame  { get => AdventureInfo.SecondsToFame; set => AdventureInfo.SecondsToFame  = value; }
     public override IReadOnlyList<InventoryPouch> Inventory { get => Items.Inventory; set => Items.Inventory = value; }
 
     protected override void SetDex(PKM pk) => Zukan.SetDex(pk);

--- a/PKHeX.Core/Saves/Substructures/Gen8/BS/FieldObjectSave8b.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/BS/FieldObjectSave8b.cs
@@ -48,7 +48,7 @@ public sealed class FieldObject8b
 
     public byte Count // cnt
     {
-        get => Data[0] ;
+        get => Data[0];
         set => Data[0] = value;
     }
 

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
@@ -658,11 +658,7 @@ public partial class StatEditor : UserControl
 
         switch (format)
         {
-            case 1:
-                TB_IVHP.Enabled = false;
-                SetEVMaskSize(Stat_HP.Size, "00000", MT_EVs);
-                break;
-            case 2:
+            case 1 or 2:
                 TB_IVHP.Enabled = false;
                 SetEVMaskSize(Stat_HP.Size, "00000", MT_EVs);
                 break;


### PR DESCRIPTION
SAV3: extract struct slice fetch
Metadata: allow setting `Memory<byte>` instead of `byte[]` Stats: deduplicate gen1/2 mask set
remove some unnecessary spaces (lol)