### PR TITLE
Fix ageto antishiny recognition

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/Colo/EncounterGift3Colo.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/Colo/EncounterGift3Colo.cs
@@ -150,7 +150,7 @@ public sealed record EncounterGift3Colo : IEncounterable, IEncounterMatch, IEnco
     }
     #endregion
 
-    public bool IsCompatible(PIDType type, PKM pk) => type is PIDType.CXD;
+    public bool IsCompatible(PIDType type, PKM pk) => type is PIDType.CXD or PIDType.CXDAnti;
 
     public PIDType GetSuggestedCorrelation() => PIDType.CXD;
 

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3.cs
@@ -8,7 +8,7 @@ namespace PKHeX.Core;
 /// <summary>
 /// Generation 3 Event Gift
 /// </summary>
-public sealed class EncounterGift3 : IEncounterable, IEncounterMatch, IMoveset, IFatefulEncounterReadOnly,
+public sealed record EncounterGift3 : IEncounterable, IEncounterMatch, IMoveset, IFatefulEncounterReadOnly,
     IRibbonSetEvent3, IRandomCorrelationEvent3, IFixedTrainer, IMetLevel
 {
     public ushort Species { get; }

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3JPN.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3JPN.cs
@@ -6,7 +6,7 @@ namespace PKHeX.Core;
 /// Generation 3 Event Gift
 /// </summary>
 /// <remarks>Specialized for the PCJP gift distribution machines.</remarks>
-public sealed class EncounterGift3JPN(ushort Species, Distribution3JPN Distribution)
+public sealed record EncounterGift3JPN(ushort Species, Distribution3JPN Distribution)
     : IEncounterable, IEncounterMatch, IRandomCorrelationEvent3, IFixedTrainer
 {
     public ushort Species { get; } = Species;

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3NY.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/Gifts/EncounterGift3NY.cs
@@ -7,7 +7,7 @@ namespace PKHeX.Core;
 /// Generation 3 Event Gift
 /// </summary>
 /// <remarks>Specialized for the PCNY gift distribution machines.</remarks>
-public sealed class EncounterGift3NY(ushort Species, Distribution3NY Distribution, byte Level, Moveset Moves)
+public sealed record EncounterGift3NY(ushort Species, Distribution3NY Distribution, byte Level, Moveset Moves)
     : IEncounterable, IEncounterMatch, IRandomCorrelationEvent3, IFixedTrainer, IMoveset
 {
     public ushort Species { get; } = Species;


### PR DESCRIPTION
Must have been omitted in the refactor

while we're here, revise the other gift3's to be records for the autogen'd ToString

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Improvements**
	- Enhanced compatibility logic for encounter gift templates in Gen3 Pokémon encounters
	- Converted several encounter gift classes to more efficient record types, improving data handling and immutability

- **Technical Updates**
	- Updated `EncounterGift3Colo` to support additional PID type checks
	- Transformed `EncounterGift3`, `EncounterGift3JPN`, and `EncounterGift3NY` from classes to records

<!-- end of auto-generated comment: release notes by coderabbit.ai -->